### PR TITLE
[Refactor] 스타일 밀림현상 개선

### DIFF
--- a/src/widgets/home/components/recent-ticket/recent-ticket-list/recent-ticket-list.css.ts
+++ b/src/widgets/home/components/recent-ticket/recent-ticket-list/recent-ticket-list.css.ts
@@ -4,6 +4,6 @@ export const container = style({
   display: "flex",
   gap: "1.2rem",
   overflowX: "auto",
-  marginRight: "-1.5em",
+  marginRight: "-2.5em",
   paddingRight: "1.5rem",
 });

--- a/src/widgets/home/components/review/review.css.ts
+++ b/src/widgets/home/components/review/review.css.ts
@@ -5,7 +5,7 @@ export const container = style({
   display: "flex",
   gap: "1.2rem",
   overflowX: "auto",
-  marginRight: "-1.5em",
+  marginRight: "-2.5em",
   paddingRight: "1.5rem",
   WebkitOverflowScrolling: "touch",
 });


### PR DESCRIPTION
## 🔍 관련 이슈 (Related Issues)

<!-- 이번 작업과 연결된 이슈 번호를 적어주세요 -->

- Closes #130 
<!-- - Related to # -->

## 📝 변경 사항 요약 (Summary)

<!-- 이번 PR에서 어떤 부분이 변경되었는지 간단히 정리해주세요 -->

스타일 밀림현상 개선

## 🎯 작업 내용 상세 (Details)

<!-- 작업 과정, 고려한 부분, 구현 방식 등을 조금 더 구체적으로 설명해주세요 -->

과거 캐러셀 UI에서 첫 번째 카드가 좌측으로 1~3px 정도 잘려 보이는 스타일 밀림 문제가 있었습니다.

처음에는 상위 컨테이너에 padding-left: 1.5rem이 있으므로,
하위 캐러셀 컨테이너에 margin-left: -1.5rem을 적용하면 해결될 것으로 예상했습니다.
하지만 실제 렌더링에서는 다음 요소들이 누적되어 더 큰 오차가 발생했습니다:

부모 padding(1.5rem)
flex + gap(1.2rem) 조합에서 발생하는 subpixel 계산
자식 요소 border/padding에 의한 미세 offset
overflow-x: auto 환경의 브라우저별 subpixel rounding

이러한 누적 오차로 인해 -1.5rem으로는 부족했고,
margin-right: -2.5rem 적용 시 가장 자연스러운 정렬이 이루어지는 것을 확인하여 수정했습니다.

<!-- ##
📸 스크린샷 (Screenshots)
 -->

<!-- UI 변경이 있다면 Before / After 형식으로 첨부해주세요 -->
| Before | After |
|--------|-------|
| <img width="876" height="446" alt="image" src="https://github.com/user-attachments/assets/a861f8ae-cede-4799-9b99-840f9aba5643" /> | <img width="880" height="406" alt="image" src="https://github.com/user-attachments/assets/ee15fa1d-9766-40c8-ab40-07f353704027" /> |

## 💬 리뷰어 참고사항 (Notes for Reviewers)

<!-- 리뷰 시 중점적으로 봐주면 좋을 내용이나 참고 사항이 있다면 적어주세요 -->
