### PR TITLE
[Refactor] 티켓 상세 페이지 좌석 배치도 Skeleton 적용

### DIFF
--- a/src/pages/ticket-detail/ticket-detail.tsx
+++ b/src/pages/ticket-detail/ticket-detail.tsx
@@ -21,7 +21,7 @@ const TicketDetail = () => {
   const { ticketId } = useParams<{ ticketId: string }>();
   const numericTicketId = Number(ticketId);
 
-  const { data: ticketDetail = null } = useQuery(
+  const { data: ticketDetail = null, isLoading } = useQuery(
     TICKET_QUERY_OPTIONS.TICKET_DETAIL(numericTicketId),
   );
 

--- a/src/pages/ticket-detail/ticket-detail.tsx
+++ b/src/pages/ticket-detail/ticket-detail.tsx
@@ -21,7 +21,7 @@ const TicketDetail = () => {
   const { ticketId } = useParams<{ ticketId: string }>();
   const numericTicketId = Number(ticketId);
 
-  const { data: ticketDetail = null, isLoading } = useQuery(
+  const { data: ticketDetail = null } = useQuery(
     TICKET_QUERY_OPTIONS.TICKET_DETAIL(numericTicketId),
   );
 

--- a/src/shared/components/skeleton/skeleton.css.ts
+++ b/src/shared/components/skeleton/skeleton.css.ts
@@ -1,0 +1,36 @@
+import { keyframes, style } from "@vanilla-extract/css";
+
+import { themeVars } from "@shared/styles/theme.css";
+
+const shimmer = keyframes({
+  "0%": {
+    backgroundPosition: "-46.8rem 0",
+  },
+  "100%": {
+    backgroundPosition: "46.8rem 0",
+  },
+});
+
+export const skeleton = style({
+  display: "block",
+
+  backgroundColor: themeVars.color.grayscale7,
+  backgroundImage: `linear-gradient(
+    90deg,
+    ${themeVars.color.grayscale7} 0rem,
+    ${themeVars.color.grayscale8} 4rem,
+    ${themeVars.color.grayscale7} 8rem
+  )`,
+
+  backgroundSize: "46.8rem 100%",
+
+  animation: `${shimmer} 1.2s ease-in-out infinite`,
+});
+
+export const rectangular = style({
+  borderRadius: "0.4rem",
+});
+
+export const circular = style({
+  borderRadius: "50%",
+});

--- a/src/shared/components/skeleton/skeleton.tsx
+++ b/src/shared/components/skeleton/skeleton.tsx
@@ -1,0 +1,29 @@
+import * as styles from "./skeleton.css";
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  variant?: "rectangular" | "circular";
+  className?: string;
+}
+
+export const Skeleton = ({
+  width = "100%",
+  height = "1rem",
+  variant = "rectangular",
+  className,
+}: SkeletonProps) => {
+  const widthValue = typeof width === "number" ? `${width}px` : width;
+  const heightValue = typeof height === "number" ? `${height}px` : height;
+
+  const shapeClass = variant === "circular" ? styles.circular : styles.rectangular;
+
+  return (
+    <div
+      className={`${styles.skeleton} ${shapeClass}${className ? ` ${className}` : ""}`}
+      style={{ width: widthValue, height: heightValue }}
+    />
+  );
+};
+
+export default Skeleton;

--- a/src/widgets/ticket-detail/components/seat-map/seat-map.tsx
+++ b/src/widgets/ticket-detail/components/seat-map/seat-map.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+
+import Skeleton from "@shared/components/skeleton/skeleton";
+
 import * as styles from "./seat-map.css";
 
 type SeatMapProps = {
@@ -5,11 +9,28 @@ type SeatMapProps = {
 };
 
 const SeatMap = ({ imageSrc }: SeatMapProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+
   if (!imageSrc) {
     return null;
   }
 
-  return <img src={imageSrc} alt="좌석 배치도" className={styles.seatImage} />;
+  const handleImageLoad = () => {
+    setIsLoading(false);
+  };
+
+  return (
+    <>
+      {isLoading && <Skeleton width="37.5rem" height="37.6rem" className={styles.seatImage} />}
+      <img
+        src={imageSrc}
+        alt="좌석 배치도"
+        className={styles.seatImage}
+        onLoad={handleImageLoad}
+        style={{ display: isLoading ? "none" : "block" }}
+      />
+    </>
+  );
 };
 
 export default SeatMap;

--- a/src/widgets/ticket-detail/components/seat-map/seat-map.tsx
+++ b/src/widgets/ticket-detail/components/seat-map/seat-map.tsx
@@ -1,34 +1,22 @@
-import { useState } from "react";
-
 import Skeleton from "@shared/components/skeleton/skeleton";
 
 import * as styles from "./seat-map.css";
 
 type SeatMapProps = {
   imageSrc?: string;
+  isLoading?: boolean;
 };
 
-const SeatMap = ({ imageSrc }: SeatMapProps) => {
-  const [isLoading, setIsLoading] = useState(true);
-
+const SeatMap = ({ imageSrc, isLoading }: SeatMapProps) => {
   if (!imageSrc) {
     return null;
   }
 
-  const handleImageLoad = () => {
-    setIsLoading(false);
-  };
-
   return (
     <>
       {isLoading && <Skeleton width="37.5rem" height="37.6rem" className={styles.seatImage} />}
-      <img
-        src={imageSrc}
-        alt="좌석 배치도"
-        className={styles.seatImage}
-        onLoad={handleImageLoad}
-        style={{ display: isLoading ? "none" : "block" }}
-      />
+
+      {!isLoading && <img src={imageSrc} alt="좌석 배치도" className={styles.seatImage} />}
     </>
   );
 };


### PR DESCRIPTION
## 🔍 관련 이슈 (Related Issues)

<!-- 이번 작업과 연결된 이슈 번호를 적어주세요 -->

- Closes #132 
<!-- - Related to # -->

## 📝 변경 사항 요약 (Summary)

<!-- 이번 PR에서 어떤 부분이 변경되었는지 간단히 정리해주세요 -->
- Skeleton 컴포넌트를 공통 컴포넌트로 추가하고, 티켓 상세 페이지의 `SeatMap` 이미지에 로딩 시 Skeleton UI를 적용했습니다.
- 이미지 로드 완료 시점까지 Skeleton이 노출되고, `onLoad` 이벤트가 발생하면 실제 이미지로 자연스럽게 전환되도록 처리했습니다.


## 🎯 작업 내용 상세 (Details)

<!-- 작업 과정, 고려한 부분, 구현 방식 등을 조금 더 구체적으로 설명해주세요 -->
### Skeleton 컴포넌트 공통화
- `shared/components/skeleton/` 경로에 Skeleton 컴포넌트를 추가했습니다.
- props
  - `width`, `height` → 숫자 입력 시 px로 변환됩니다.
  - variant → `rectangular` / `circular` 두 가지 형태를 지원합니다.

### SeatMap 로딩 상태 로직 추가
- `useState(true)`로 이미지 로딩 여부를 관리하도록 했습니다.
- 로직 흐름
```ts
isLoading === true  → Skeleton 표시  
isLoading === false → 실제 이미지 표시
```
- `onLoad` 이벤트에서 `setIsLoading(false)` 호출해 Skeleton을 제거합니다.

### SeatMap 컴포넌트 반영
```ts
{isLoading && (
  <Skeleton
    width="37.5rem"
    height="37.6rem"
    className={styles.seatImage}
  />
)}
```
- 이미지 로딩 상태를 관리하기 위해 `isLoading` 상태를 추가했습니다.
  - 최초 렌더 시 `isLoading = true`이 적용됩니다.
  - `img`의 `onLoad`에서 `setIsLoading(false)`를 호출합니다.
- Skeleton 사이즈는 현재 `SeatMap` 이미지 크기와 동일하게 지정해 레이아웃 변화(LCP shift) 없이 전환되도록 했습니다.
- Skeleton과 이미지 모두 같은 class(`seatImage`)를 사용하여 적용되는 스타일이 유지되도록 했습니다.
- 실제 이미지는 `style={{ display: isLoading ? "none" : "block" }}`로 토글해 로딩 중에는 Skeleton만 보이고 로딩 완료 후 Skeleton은 사라지고 이미지가 자연스럽게 노출되도록 했습니다.


## 📸 스크린샷 (Screenshots)
### before

https://github.com/user-attachments/assets/b4f7a3d7-1720-47cc-839e-c86fa8e280cc




### after

https://github.com/user-attachments/assets/d605eb54-727b-4f97-8ee3-e46ca3cee737



<!-- UI 변경이 있다면 Before / After 형식으로 첨부해주세요 -->
<!-- 예시:
| Before | After |
|--------|-------|
| 이미지 | 이미지 |
-->

## 💬 리뷰어 참고사항 (Notes for Reviewers)

<!-- 리뷰 시 중점적으로 봐주면 좋을 내용이나 참고 사항이 있다면 적어주세요 -->
- Skeleton의 색상(그레이 톤)과 애니메이션 속도(1.2s)가 적절한지 확인 부탁드립니다.
- Skeleton은 단순 placeholder 용도라 `width`/`height`를 px로 입력하는 경우가 많아, 숫자 입력 시 rem으로 강제 변환하지 않고 그대로 px로 처리하도록 유지했습니다. 그래도 팀 컨벤션에 맞게 rem단위로 입력하는게 맞으면 수정하도록 하겠습니다!
